### PR TITLE
Add BaseEntity and University classes with licensing info

### DIFF
--- a/src/UniversitySystem.Domain/Common/BaseEntity.cs
+++ b/src/UniversitySystem.Domain/Common/BaseEntity.cs
@@ -1,0 +1,18 @@
+﻿/*
+ * Copyright (c) 2025 AOLabs
+ * This file is part of the AOLabs University System project.
+ *
+ * Licensed under the MIT License.
+ * You may obtain a copy of the License at:
+ * https://opensource.org/licenses/MIT
+ *
+ * You are free to use, modify, and distribute this file
+ * under the terms of the license.
+ */
+
+namespace UniversitySystem.Domain.Common;
+
+public abstract class BaseEntity
+{
+    public Guid Id { get; set; }
+}

--- a/src/UniversitySystem.Domain/Entities/University.cs
+++ b/src/UniversitySystem.Domain/Entities/University.cs
@@ -1,0 +1,23 @@
+﻿/*
+ * Copyright (c) 2025 AOLabs
+ * This file is part of the AOLabs University System project.
+ *
+ * Licensed under the MIT License.
+ * You may obtain a copy of the License at:
+ * https://opensource.org/licenses/MIT
+ *
+ * You are free to use, modify, and distribute this file
+ * under the terms of the license.
+ */
+
+using UniversitySystem.Domain.Common;
+
+namespace UniversitySystem.Domain.Entities;
+
+public class University : BaseEntity
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Location { get; set; }
+
+    public ICollection<Faculty> Faculties { get; set; } = new List<Faculty>();
+}


### PR DESCRIPTION
Introduce an abstract class `BaseEntity` with an `Id` property to serve as a base for other entities. Create a `University` class that inherits from `BaseEntity`, including properties for `Name`, `Location`, and a collection of `Faculties`. Add copyright and MIT License information to both files.

Closes #1
