### PR TITLE
Add Faculty class with properties and licensing info

### DIFF
--- a/src/UniversitySystem.Domain/Entities/Faculty.cs
+++ b/src/UniversitySystem.Domain/Entities/Faculty.cs
@@ -1,0 +1,27 @@
+﻿/*
+ * Copyright (c) 2025 AOLabs
+ * This file is part of the AOLabs University System project.
+ *
+ * Licensed under the MIT License.
+ * You may obtain a copy of the License at:
+ * https://opensource.org/licenses/MIT
+ *
+ * You are free to use, modify, and distribute this file
+ * under the terms of the license.
+ */
+
+using UniversitySystem.Domain.Common;
+
+namespace UniversitySystem.Domain.Entities;
+
+public class Faculty : BaseEntity
+{
+    public string Name { get; set; } = string.Empty;
+
+    // Foreign Key to University
+    public Guid UniversityId { get; set; }
+    public University University { get; set; } = default!;
+
+    // Navigation to Departments
+    public ICollection<Department> Departments { get; set; } = new List<Department>();
+}


### PR DESCRIPTION
This commit introduces a new `Faculty` class in the `UniversitySystem.Domain.Entities` namespace. The class inherits from `BaseEntity` and includes properties for `Name`, `UniversityId`, a navigation property for
`University`, and a collection of `Departments`. A copyright notice and MIT License information have also been added at the top of the file.

Closes #2 