### PR TITLE
Add Specialization class with department linkage

### DIFF
--- a/src/UniversitySystem.Domain/Entities/Specialization.cs
+++ b/src/UniversitySystem.Domain/Entities/Specialization.cs
@@ -1,0 +1,24 @@
+﻿/*
+ * Copyright (c) 2025 AOLabs
+ * This file is part of the AOLabs University System project.
+ *
+ * Licensed under the MIT License.
+ * You may obtain a copy of the License at:
+ * https://opensource.org/licenses/MIT
+ *
+ * You are free to use, modify, and distribute this file
+ * under the terms of the license.
+ */
+
+using UniversitySystem.Domain.Common;
+
+namespace UniversitySystem.Domain.Entities;
+
+public class Specialization : BaseEntity
+{
+    public string Name { get; set; } = string.Empty;
+
+    // Foreign key to Department
+    public Guid DepartmentId { get; set; }
+    public Department Department { get; set; } = default!;
+}


### PR DESCRIPTION
This commit introduces a new file, `Specialization.cs`, which defines the `Specialization` class. The class inherits from `BaseEntity` and includes properties for `Name`, `DepartmentId`, and a navigation property for `Department`. This structure facilitates the representation of specializations within the university system, establishing a foreign key relationship with departments.

Closes #4 